### PR TITLE
radio: keep runtime handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eSDR
 
-A Software Defined Radio app written in Rust with [FortuneSDR](https://www.fortunesdr.org/), inspired by GNU Radio.
+A Software Defined Radio app written in Rust with [FutureSDR](https://www.futuresdr.org/), inspired by GNU Radio.
 
 ## Adding new blocks
 


### PR DESCRIPTION
Dropping the runtime handle let to a panic when the flowgraph is terminated. This stores the runtime as part of the `Radio` struct.